### PR TITLE
fix: persist giraf-core media files across container restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     build: ../giraf-core
     ports:
       - "8000:8000"
+    volumes:
+      - core-media-data:/app/media
     depends_on:
       core-db:
         condition: service_healthy
@@ -84,4 +86,5 @@ services:
 
 volumes:
   core-db-data:
+  core-media-data:
   weekplanner-db-data:


### PR DESCRIPTION
Pictogram images returned 404 because generated files were stored in the container's ephemeral filesystem. The DB records survived (volume-backed) but the actual image files did not. Adding a named volume for /app/media ensures uploaded and AI-generated pictogram images persist.

# Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes #\<issue_no>

## Type of change
*Delete unchecked boxes (only for Type of change)*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration*


**Development Configuration**
*Type "flutter --version" and "dart --version" in your CMD to check versions.*

* Flutter version:
* Dart version:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [ ] I have Acceptance Tested this on an Android device
