### PR TITLE
fix: switch giraf-core to production Django settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,22 @@
 # giraf-deploy — Environment Variables
 # Copy to .env and fill in required values.
 
+# Django secret key — generate with: openssl rand -hex 32
+DJANGO_SECRET_KEY=
+
 # Shared JWT signing key — must match across all services
 # Generate one with: openssl rand -hex 32
 JWT_SECRET=
 
 # PostgreSQL password (used by all databases)
 GIRAF_DB_PASSWORD=localdev123
+
+# Allowed hosts (comma-separated). Set to your server IP/domain in production.
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+# CORS allowed origins (comma-separated, full URLs with scheme).
+# Example: http://localhost:3000,http://130.225.39.225:5171
+CORS_ALLOWED_ORIGINS=
 
 # giraf-ai providers (use "mock" for local dev)
 IMAGE_PROVIDER=mock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,18 @@ services:
       timeout: 5s
       retries: 5
 
+  core-redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - core-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   core-api:
     build: ../giraf-core
     ports:
@@ -25,16 +37,22 @@ services:
     depends_on:
       core-db:
         condition: service_healthy
+      core-redis:
+        condition: service_healthy
     environment:
-      DJANGO_SETTINGS_MODULE: config.settings.dev
+      DJANGO_SETTINGS_MODULE: config.settings.prod
       POSTGRES_DB: giraf_core
       POSTGRES_USER: giraf
       POSTGRES_PASSWORD: ${GIRAF_DB_PASSWORD:-localdev123}
       POSTGRES_HOST: core-db
       POSTGRES_PORT: "5432"
-      DJANGO_SECRET_KEY: dev-secret-key-change-me
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
       JWT_SECRET: ${JWT_SECRET}
       GIRAF_AI_URL: "http://giraf-ai:8100"
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      SECURE_SSL_REDIRECT: "false"
+      REDIS_URL: redis://core-redis:6379/0
 
     command: >
       sh -c "uv run python manage.py migrate &&
@@ -88,4 +106,5 @@ services:
 volumes:
   core-db-data:
   core-media-data:
+  core-redis-data:
   weekplanner-db-data:


### PR DESCRIPTION
## Summary

- Switches `DJANGO_SETTINGS_MODULE` from `config.settings.dev` to `config.settings.prod`
- Adds Redis service (required by prod cache backend for rate limiting)
- Sources `DJANGO_SECRET_KEY` from `.env` instead of hardcoding `dev-secret-key-change-me`
- Adds `ALLOWED_HOSTS`, `CORS_ALLOWED_ORIGINS`, `SECURE_SSL_REDIRECT` env vars
- Disables SSL redirect (Strato deployment uses plain HTTP)
- Updates `.env.example` with all new required variables

Relates to aau-giraf/giraf-core#18

## Deployment notes

After merging, the `.env` on the Strato VM needs these new variables:

```bash
DJANGO_SECRET_KEY=<generate with: openssl rand -hex 32>
ALLOWED_HOSTS=130.225.39.225,localhost
CORS_ALLOWED_ORIGINS=http://130.225.39.225:5171
```

Then `docker compose up -d --build` to rebuild with prod settings.

## Test plan

- [x] `docker compose config` validates successfully
- [ ] Deploy on Strato and verify CORS rejects `evil-attacker.com` origins
- [ ] Verify API still responds to requests from allowed origins