### PR TITLE
refactor: per-repo env_file config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,5 @@
-# giraf-deploy — Environment Variables
-# Copy to .env and fill in required values.
+# giraf-deploy — Shared Environment Variables
+# Copy to .env. Only variables shared across multiple services belong here.
 
-# Django secret key — generate with: openssl rand -hex 32
-DJANGO_SECRET_KEY=
-
-# Shared JWT signing key — must match across all services
-# Generate one with: openssl rand -hex 32
-JWT_SECRET=
-
-# PostgreSQL password (used by all databases)
+# PostgreSQL password (used by core-db and weekplanner-db)
 GIRAF_DB_PASSWORD=localdev123
-
-# Allowed hosts (comma-separated). Set to your server IP/domain in production.
-ALLOWED_HOSTS=localhost,127.0.0.1
-
-# CORS allowed origins (comma-separated, full URLs with scheme).
-# Example: http://localhost:3000,http://130.225.39.225:5171
-CORS_ALLOWED_ORIGINS=
-
-# giraf-ai providers (use "mock" for local dev)
-IMAGE_PROVIDER=mock
-TTS_PROVIDER=mock
-# OPENAI_API_KEY=
-# GOOGLE_TTS_CREDENTIALS=

--- a/README.md
+++ b/README.md
@@ -53,6 +53,39 @@ All backend services will be available once the health checks pass.
 | `OPENAI_API_KEY` | No | — | Required if `IMAGE_PROVIDER=openai` |
 | `GOOGLE_TTS_CREDENTIALS` | No | — | Required if `TTS_PROVIDER=google` |
 
+## Production Deployment
+
+The default `docker-compose.yml` uses `ASPNETCORE_ENVIRONMENT=Development` for the weekplanner API. For production deployments, override the following:
+
+```yaml
+# docker-compose.prod.yml or environment overrides
+weekplanner-api:
+  environment:
+    ASPNETCORE_ENVIRONMENT: Production
+    AllowedOrigins__0: https://your-frontend-domain.com
+    AllowedOrigins__1: https://another-allowed-origin.com
+```
+
+### What changes in Production mode
+
+| Feature | Development | Production |
+|---------|-------------|------------|
+| CORS | Allow all origins | Only origins in `AllowedOrigins` (fails on startup if missing) |
+| API docs | Scalar UI at `/scalar/v1`, OpenAPI at `/openapi/v1.json` | Not available (404) |
+| Rate limiting | 60 req/min per IP (active in all environments) | Same |
+
+### Strato deployment (AAU HPC)
+
+On the Strato VM (`130.225.39.225`), set environment variables in the `.env` file or override in the compose:
+
+```bash
+# Required for production
+ASPNETCORE_ENVIRONMENT=Production
+AllowedOrigins__0=http://130.225.39.225:5171
+```
+
+The weekplanner API uses `X-Forwarded-For` headers for per-IP rate limiting. If running behind a reverse proxy, ensure it forwards client IPs.
+
 ## Useful Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Docker Compose orchestration for the full GIRAF stack.
 
 ## Services
 
-| Service | Port | Source |
-|---------|------|--------|
-| `core-db` | 5432 | PostgreSQL 16 |
-| `core-api` | 8000 | [giraf-core](https://github.com/aau-giraf/giraf-core) (Django) |
-| `giraf-ai` | 8100 | [giraf-ai](https://github.com/aau-giraf/giraf-ai) (FastAPI) |
-| `weekplanner-db` | 5433 | PostgreSQL 15 |
-| `weekplanner-api` | 5171 | [weekplanner](https://github.com/aau-giraf/weekplanner) (.NET 8) |
+| Service | Port | Source | Docs (dev) | Health |
+|---------|------|--------|------------|--------|
+| `core-db` | 5432 (localhost) | PostgreSQL 16 | — | — |
+| `core-redis` | 6379 (localhost) | Redis 7 | — | — |
+| `core-api` | 8000 | [giraf-core](https://github.com/aau-giraf/giraf-core) | `/api/v1/docs` | `/api/v1/health` |
+| `giraf-ai` | 8100 | [giraf-ai](https://github.com/aau-giraf/giraf-ai) | `/docs` | — |
+| `weekplanner-db` | 5433 (localhost) | PostgreSQL 15 | — | — |
+| `weekplanner-api` | 5171 | [weekplanner](https://github.com/aau-giraf/weekplanner) | `/scalar/v1` | `/health` |
 
 ## Prerequisites
 
 - Docker and Docker Compose
-- The following repos cloned as siblings:
+- Repos cloned as siblings:
 
 ```
 GIRAF/
@@ -25,76 +26,97 @@ GIRAF/
 └── giraf-deploy/       ← you are here
 ```
 
+## Configuration
+
+Each service reads its own `.env` file. Compose just wires up networking, volumes, and DB connections.
+
+| File | What goes in it |
+|------|----------------|
+| `giraf-core/.env` | Django settings, JWT secret, DB creds, CORS |
+| `giraf-ai/.env` | AI provider keys, JWT secret, debug flag |
+| `weekplanner/.env` | JWT secret, ASP.NET environment |
+| `giraf-deploy/.env` | Shared DB password only |
+
+Each repo has a `.env.example` — copy and fill in values. Dev vs prod is controlled by what's in these files, not by swapping compose files.
+
+### Dev setup
+
+```bash
+# Copy .env.example → .env in each repo and fill in values
+cp ../giraf-core/.env.example ../giraf-core/.env
+cp ../giraf-ai/.env.example ../giraf-ai/.env
+cp ../weekplanner/.env.example ../weekplanner/.env
+cp .env.example .env
+
+# At minimum, set JWT_SECRET to the same value in giraf-core, giraf-ai, and weekplanner:
+#   JWT_SECRET=<generate with: openssl rand -hex 32>
+# Set DJANGO_SETTINGS_MODULE=config.settings.dev in giraf-core/.env
+# Set DEBUG=true in giraf-ai/.env
+```
+
+### Prod setup
+
+Same files, different values:
+
+```bash
+# giraf-core/.env
+DJANGO_SETTINGS_MODULE=config.settings.prod
+DJANGO_SECRET_KEY=<random>
+JWT_SECRET=<shared secret>
+ALLOWED_HOSTS=130.225.39.225
+CORS_ALLOWED_ORIGINS=http://130.225.39.225:8000
+
+# giraf-ai/.env
+JWT_SECRET=<same shared secret>
+IMAGE_PROVIDER=gemini
+GEMINI_API_KEY=<key>
+DEBUG=false
+
+# weekplanner/.env
+JWT_SECRET=<same shared secret>
+ASPNETCORE_ENVIRONMENT=Production
+```
+
 ## Quick Start
 
 ```bash
-# 1. Create .env from template
-cp .env.example .env    # Edit as needed
+# 1. Set up .env files (see above)
 
 # 2. Start everything
 docker compose up
 
-# 3. (Optional) Start the Expo frontend
+# 3. Seed test data (dev mode only)
+docker compose exec core-api uv run python manage.py seed_dev_data
+./seed_activities.sh
+
+# 4. Run the Flutter frontend
 cd ../weekplanner/frontend
-npm install
-npx expo start
+flutter run -d chrome
 ```
 
-All backend services will be available once the health checks pass.
-
-## Environment Variables
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `JWT_SECRET` | Yes | — | Shared JWT signing key (min 32 chars) |
-| `GIRAF_DB_PASSWORD` | No | `localdev123` | PostgreSQL password for all databases |
-| `IMAGE_PROVIDER` | No | `mock` | giraf-ai image provider (`mock` or `openai`) |
-| `TTS_PROVIDER` | No | `mock` | giraf-ai TTS provider (`mock` or `google`) |
-| `OPENAI_API_KEY` | No | — | Required if `IMAGE_PROVIDER=openai` |
-| `GOOGLE_TTS_CREDENTIALS` | No | — | Required if `TTS_PROVIDER=google` |
-
-## Production Deployment
-
-The default `docker-compose.yml` uses `ASPNETCORE_ENVIRONMENT=Development` for the weekplanner API. For production deployments, override the following:
-
-```yaml
-# docker-compose.prod.yml or environment overrides
-weekplanner-api:
-  environment:
-    ASPNETCORE_ENVIRONMENT: Production
-    AllowedOrigins__0: https://your-frontend-domain.com
-    AllowedOrigins__1: https://another-allowed-origin.com
-```
-
-### What changes in Production mode
-
-| Feature | Development | Production |
-|---------|-------------|------------|
-| CORS | Allow all origins | Only origins in `AllowedOrigins` (fails on startup if missing) |
-| API docs | Scalar UI at `/scalar/v1`, OpenAPI at `/openapi/v1.json` | Not available (404) |
-| Rate limiting | 60 req/min per IP (active in all environments) | Same |
-
-### Strato deployment (AAU HPC)
-
-On the Strato VM (`130.225.39.225`), set environment variables in the `.env` file or override in the compose:
+## Updating the Deployment
 
 ```bash
-# Required for production
-ASPNETCORE_ENVIRONMENT=Production
-AllowedOrigins__0=http://130.225.39.225:5171
-```
+# Pull latest on all repos
+cd ~/giraf
+for repo in giraf-core giraf-ai weekplanner giraf-deploy; do
+  cd ~/giraf/$repo && git pull
+done
 
-The weekplanner API uses `X-Forwarded-For` headers for per-IP rate limiting. If running behind a reverse proxy, ensure it forwards client IPs.
+# Rebuild and restart
+cd ~/giraf/giraf-deploy
+docker compose down -v    # -v wipes volumes (only if no valuable data)
+docker compose up -d --build
+
+# Re-seed (dev mode only)
+docker compose exec core-api uv run python manage.py seed_dev_data
+./seed_activities.sh
+```
 
 ## Useful Commands
 
 ```bash
-# Rebuild after code changes
-docker compose up --build
-
-# Reset databases
-docker compose down -v
-
-# View logs for a specific service
-docker compose logs -f core-api
+docker compose up --build       # Rebuild after code changes
+docker compose down -v          # Reset databases
+docker compose logs -f core-api # View logs for a service
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@ services:
   # ── giraf-core (Django) ─────────────────────────────────
   core-db:
     image: postgres:16-alpine
+    restart: unless-stopped
     environment:
       POSTGRES_DB: giraf_core
       POSTGRES_USER: giraf
       POSTGRES_PASSWORD: ${GIRAF_DB_PASSWORD:-localdev123}
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - core-db-data:/var/lib/postgresql/data
     healthcheck:
@@ -18,8 +19,9 @@ services:
 
   core-redis:
     image: redis:7-alpine
+    restart: unless-stopped
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - core-redis-data:/data
     healthcheck:
@@ -30,6 +32,7 @@ services:
 
   core-api:
     build: ../giraf-core
+    restart: unless-stopped
     ports:
       - "8000:8000"
     volumes:
@@ -39,21 +42,13 @@ services:
         condition: service_healthy
       core-redis:
         condition: service_healthy
+    env_file: ../giraf-core/.env
     environment:
-      DJANGO_SETTINGS_MODULE: config.settings.prod
-      POSTGRES_DB: giraf_core
-      POSTGRES_USER: giraf
-      POSTGRES_PASSWORD: ${GIRAF_DB_PASSWORD:-localdev123}
+      # These override .env because they're internal to the compose network
       POSTGRES_HOST: core-db
       POSTGRES_PORT: "5432"
-      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
-      JWT_SECRET: ${JWT_SECRET}
       GIRAF_AI_URL: "http://giraf-ai:8100"
-      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
-      SECURE_SSL_REDIRECT: "false"
       REDIS_URL: redis://core-redis:6379/0
-
     command: >
       sh -c "uv run python manage.py migrate &&
              uv run python manage.py runserver 0.0.0.0:8000"
@@ -61,24 +56,21 @@ services:
   # ── giraf-ai (FastAPI) ──────────────────────────────────
   giraf-ai:
     build: ../giraf-ai
+    restart: unless-stopped
     ports:
       - "8100:8100"
-    environment:
-      JWT_SECRET: ${JWT_SECRET}
-      IMAGE_PROVIDER: ${IMAGE_PROVIDER:-mock}
-      TTS_PROVIDER: ${TTS_PROVIDER:-mock}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      GOOGLE_TTS_CREDENTIALS: ${GOOGLE_TTS_CREDENTIALS:-}
+    env_file: ../giraf-ai/.env
 
   # ── weekplanner (ASP.NET) ───────────────────────────────
   weekplanner-db:
     image: postgres:15
+    restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${GIRAF_DB_PASSWORD:-localdev123}
       POSTGRES_DB: giraf_dev
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - weekplanner-db-data:/var/lib/postgresql/data
     healthcheck:
@@ -91,17 +83,17 @@ services:
     build:
       context: ../weekplanner/backend
       dockerfile: Dockerfile
+    restart: unless-stopped
     ports:
       - "5171:5171"
     depends_on:
       weekplanner-db:
         condition: service_healthy
+    env_file: ../weekplanner/.env
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
-      ASPNETCORE_URLS: http://+:5171
+      # These override .env because they're internal to the compose network
       ConnectionStrings__DbConnection: "Host=weekplanner-db;Port=5432;Database=giraf_dev;Username=postgres;Password=${GIRAF_DB_PASSWORD:-localdev123}"
       GirafCore__BaseUrl: "http://core-api:8000"
-      JWT_SECRET: ${JWT_SECRET}
 
 volumes:
   core-db-data:

--- a/seed_activities.sh
+++ b/seed_activities.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Seed the weekplanner with demo activities for the current week.
+# Prerequisites: giraf-core seeded (seed_dev_data), all services running.
+set -euo pipefail
+
+CORE_URL="${CORE_URL:-http://localhost:8000}"
+WP_URL="${WP_URL:-http://localhost:5171}"
+GIRAF_USER="${GIRAF_USER:-anna}"
+GIRAF_PASS="${GIRAF_PASS:-devpass123}"
+
+echo "=== Logging in as $GIRAF_USER ==="
+TOKEN=$(curl -sf -X POST "$CORE_URL/api/v1/token/pair" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$GIRAF_USER\",\"password\":\"$GIRAF_PASS\"}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access'])")
+echo "Got JWT token"
+
+AUTH="Authorization: Bearer $TOKEN"
+
+echo "=== Looking up org, citizen, and pictogram IDs ==="
+# API returns paginated responses: {"items": [...], "count": N}
+
+ORG_ID=$(curl -sf -H "$AUTH" "$CORE_URL/api/v1/organizations" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['items'][0]['id'])")
+echo "Org ID: $ORG_ID"
+
+CITIZEN_ID=$(curl -sf -H "$AUTH" "$CORE_URL/api/v1/organizations/$ORG_ID/citizens" \
+  | python3 -c "import sys,json; c=json.load(sys.stdin)['items'][0]; print(c['id'])")
+echo "Citizen ID: $CITIZEN_ID"
+
+# Include org-scoped pictograms with ?organization_id=
+PICTOS=$(curl -sf -H "$AUTH" "$CORE_URL/api/v1/pictograms?organization_id=$ORG_ID")
+echo "Pictograms:"
+echo "$PICTOS" | python3 -c "
+import sys, json
+for p in json.load(sys.stdin)['items']:
+    print(f\"  {p['id']}: {p['name']}\")"
+
+picto_id() {
+  echo "$PICTOS" | python3 -c "
+import sys, json
+for p in json.load(sys.stdin)['items']:
+    if p['name'].lower() == '$1'.lower():
+        print(p['id']); break
+else:
+    print(json.load(open('/dev/stdin'))['items'][0]['id'])" 2>/dev/null || \
+  echo "$PICTOS" | python3 -c "import sys,json; print(json.load(sys.stdin)['items'][0]['id'])"
+}
+
+P_HAPPY=$(picto_id "Happy")
+P_EAT=$(picto_id "Eat")
+P_BUS=$(picto_id "School Bus")
+P_LUNCH=$(picto_id "Lunchroom")
+P_SAD=$(picto_id "Sad")
+
+MONDAY=$(date -d "monday this week" +%Y-%m-%d 2>/dev/null || date -d "last monday" +%Y-%m-%d)
+echo ""
+echo "=== Creating activities for week of $MONDAY ==="
+
+CREATED=()
+
+add() {
+  local offset=$1 start=$2 end=$3 pid=$4
+  local d=$(date -d "$MONDAY + $offset days" +%Y-%m-%d)
+  local r=$(curl -sf -X POST "$WP_URL/weekplan/to-citizen/$CITIZEN_ID" \
+    -H 'Content-Type: application/json' -H "$AUTH" \
+    -d "{\"date\":\"$d\",\"startTime\":\"$start\",\"endTime\":\"$end\",\"pictogramId\":$pid}")
+  local aid=$(echo "$r" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('activityId', d.get('id','?')))")
+  echo "  $d $start-$end -> #$aid"
+  CREATED+=("$aid")
+}
+
+for day in 0 1 2 3 4; do
+  echo "--- $(date -d "$MONDAY + $day days" +%A) ---"
+  add $day "08:00" "08:30" "$P_BUS"
+  add $day "09:00" "10:30" "$P_HAPPY"
+  add $day "11:30" "12:15" "$P_EAT"
+  add $day "13:00" "14:00" "$P_LUNCH"
+done
+
+echo ""
+echo "=== Marking a few as completed ==="
+for i in 0 1 2; do
+  curl -sf -X PUT "$WP_URL/weekplan/activity/${CREATED[$i]}/iscomplete?IsComplete=true" -H "$AUTH" > /dev/null
+  echo "  #${CREATED[$i]} completed"
+done
+
+echo ""
+echo "=== Done! ${#CREATED[@]} activities created ==="


### PR DESCRIPTION
## Summary
- Each service reads its own repo's `.env` via `env_file` instead of variable passthrough in compose
- `giraf-deploy/.env` only holds the shared DB password
- Eliminates fragile `${VAR:-default}` chains that caused env vars to silently disappear
- Added `restart: unless-stopped`, bound DB ports to localhost, added `seed_activities.sh`

## Test plan
- [ ] `docker compose up` with per-repo `.env` files
- [ ] Verify all services start and health checks pass
- [ ] Verify seeding works