### PR TITLE
feat: forward plapre + gemini env vars to giraf-ai

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,9 @@ services:
       TTS_PROVIDER: ${TTS_PROVIDER:-mock}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       GOOGLE_TTS_CREDENTIALS: ${GOOGLE_TTS_CREDENTIALS:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      PLAPRE_BASE_URL: ${PLAPRE_BASE_URL:-http://172.17.0.1:8200}
+      PLAPRE_CPU_BASE_URL: ${PLAPRE_CPU_BASE_URL:-http://172.17.0.1:8201}
 
   # ── weekplanner (ASP.NET) ───────────────────────────────
   weekplanner-db:


### PR DESCRIPTION
## Summary
- Forward `PLAPRE_BASE_URL`, `PLAPRE_CPU_BASE_URL`, and `GEMINI_API_KEY` from `.env` into the `giraf-ai` container.
- Unblocks switching `TTS_PROVIDER=plapre_cpu` on Strato for aau-giraf/giraf-ai#35.
- Defaults point `plapre_*_base_url` at `172.17.0.1` (Docker bridge gateway) so the container can reach the `plapre-cpu-serve` process running on the host.

## Test plan
- [ ] Merge, `git pull` on Strato, set `TTS_PROVIDER=plapre_cpu` + `PLAPRE_CPU_BASE_URL=http://172.17.0.1:8201` in `.env`.
- [ ] `docker compose up -d --build giraf-ai` — giraf-ai starts without "TTS provider failed health check" warning once the host-side plapre-cpu server is up.
- [ ] `docker compose exec giraf-ai curl -s http://172.17.0.1:8201/health` returns 200.
- [ ] End-to-end TTS request through giraf-ai `/api/v1/tts/synthesize` returns valid 24kHz mono WAV.